### PR TITLE
modules: Drop usage of nixpkgs upstream module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -7,7 +7,6 @@
     ./app.nix
     ./container.nix
     ./helpers.nix
-    ./nixpkgs.nix
     ./templates
   ];
 }

--- a/modules/nixpkgs.nix
+++ b/modules/nixpkgs.nix
@@ -1,7 +1,0 @@
-{ pkgs, ... }:
-
-{
-  nixpkgs.overlays = [
-    (import ../overlay.nix)
-  ];
-}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -7,9 +7,9 @@
 # Using this simple purely-Nix shim serves as a placeholder.
 
 let
-  # Tracking https://github.com/NixOS/nixpkgs/tree/nixos-21.11
-  rev = "a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31";
-  sha256 = "sha256:162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
+  # Tracking https://github.com/NixOS/nixpkgs/tree/nixos-unstable
+  rev = "062a0c5437b68f950b081bbfc8a699d57a4ee026";
+  sha256 = "sha256:0vfd7g1gwy9lcnnv8kclqr68pndd9sg0xq69h465zbbzb2vnijh9";
   tarball = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;

--- a/support/eval-spec.nix
+++ b/support/eval-spec.nix
@@ -11,29 +11,22 @@ let
   fromNixpkgs = map (module: "${toString pkgs.path}/nixos/modules/${module}");
   modulesFromNixpkgs = fromNixpkgs [
     "misc/assertions.nix"
-    "misc/nixpkgs.nix"
   ];
-
-  # Default nixpkgs module config
-  # Referring to the input `pkgs` needs to be done outside the actual modules eval.
-  nixpkgsConfig = {
-    nixpkgs = {
-      pkgs = lib.mkOptionDefault pkgs;
-      system = lib.mkOptionDefault pkgs.system;
-      initialSystem = lib.mkOptionDefault pkgs.system;
-    };
-  };
 in
 
 {
   eval = (lib.evalModules {
     modules = [
       # Get `pkgs` in there
-      { _module.args.pkgs = pkgs; }
+      {
+        # Prevents `<unknown-file>` from being reported.
+        _file = ./eval-spec.nix;
+        # Provides the `pkgs` argument for modules.
+        _module.args.pkgs = pkgs;
+      }
     ] ++
     modulesFromNixpkgs ++
     [
-      nixpkgsConfig
       # Import the local modules
       ../modules
       # Apply the user config


### PR DESCRIPTION
This does not address the root cause of https://github.com/fly-apps/nix-base/issues/6, the root cause of https://github.com/fly-apps/nix-base/issues/6 was the
usage of `_module.args.pkgs`, which conflicts with the updated upstream
nixpkgs module.

Instead, we're *dropping* the module. Why? Because I believe it might
cause more issues than solve issues here.

In practice it's not needed for the use case of Fly, since all
evaluations start with a pre-defined `pkgs` parameter from the overlay.
In addition, it is not expected that users would change the reference of
Nixpkgs using that module.

Fixes https://github.com/fly-apps/nix-base/issues/6.